### PR TITLE
Changed iframe URLS to use HTTPS 

### DIFF
--- a/docs/community-history.md
+++ b/docs/community-history.md
@@ -1,7 +1,7 @@
 # Community History
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-  height: 300px" src="http://www.youtube.com/embed/-zRN7XLCRhc"
+  height: 300px" src="https://www.youtube.com/embed/-zRN7XLCRhc"
   frameborder="0">
 </iframe>
 
@@ -403,6 +403,6 @@ A video I (Deirdré) made just before leaving Oracle for Joyent,
 featuring many of the people mentioned above.
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/UHOBoWJHTyc"
+    height: 300px" src="https://www.youtube.com/embed/UHOBoWJHTyc"
     frameborder="0">
 </iframe>

--- a/docs/dtrace.conf-2012-zfs-dtrace-provider.md
+++ b/docs/dtrace.conf-2012-zfs-dtrace-provider.md
@@ -1,7 +1,7 @@
 # dtrace.conf 2012 - ZFS DTrace Provider
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/m_V7yrrn49Y"
+    height: 300px" src="https://www.youtube.com/embed/m_V7yrrn49Y"
     frameborder="0">
 </iframe>
 Matt Ahrens and George Wilson of Delphix.

--- a/docs/illumos-and-smartos-basics.md
+++ b/docs/illumos-and-smartos-basics.md
@@ -58,7 +58,7 @@ general.
 ## Security
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/0EEf9y1nwYo"
+    height: 300px" src="https://www.youtube.com/embed/0EEf9y1nwYo"
     frameborder="0">
 </iframe>
 Jack Adams learns why you can't Telnet into a Solaris machine.

--- a/docs/kvm.md
+++ b/docs/kvm.md
@@ -1,7 +1,7 @@
 # KVM
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/mzz_NehKaMo"
+    height: 300px" src="https://www.youtube.com/embed/mzz_NehKaMo"
     frameborder="0">
 </iframe>
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,7 +6,7 @@
 ## Cloud Performance Training: What's in the Course
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/pb95K_2Xt-0"
+    height: 300px" src="https://www.youtube.com/embed/pb95K_2Xt-0"
     frameborder="0">
 </iframe>
 

--- a/docs/smartos-users-guide.md
+++ b/docs/smartos-users-guide.md
@@ -17,7 +17,7 @@
 ### SmartOS, a Primer for Sysadmins
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/dxZExLeJz2I"
+    height: 300px" src="https://www.youtube.com/embed/dxZExLeJz2I"
     frameborder="0"> </iframe>
 
 Ben Rockwood speaking at the BayLISA meetup at Joyent, August 16, 2012
@@ -25,7 +25,7 @@ Ben Rockwood speaking at the BayLISA meetup at Joyent, August 16, 2012
 ### SmartOS Operations
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/96PGoXHli3Q"
+    height: 300px" src="https://www.youtube.com/embed/96PGoXHli3Q"
     frameborder="0"> </iframe>
 
 Ben Rockwood at illumos Day, Oct 2012, gives a look at tools and

--- a/docs/zfs.md
+++ b/docs/zfs.md
@@ -1,7 +1,7 @@
 # ZFS
 
 <iframe class="youtube-player" type="text/html" style="width: 400px;
-    height: 300px" src="http://www.youtube.com/embed/6F9bscdqRpo"
+    height: 300px" src="https://www.youtube.com/embed/6F9bscdqRpo"
     frameborder="0">
 </iframe>
 


### PR DESCRIPTION
Some of the `iframes` are using HTTP urls while the doc is served through HTTPS so, in order to avoid browser to block the load because of the mixing context, we should change them to HTTPS.