### PR TITLE
Add missing subcommand to local image import example

### DIFF
--- a/docs/managing-images.md
+++ b/docs/managing-images.md
@@ -217,7 +217,7 @@ image server.
 ### Importing Images Locally
 
 Typically images are downloaded from an image server, however they can
-also be imported locally using: `imgadm -m <manifest> -f <file>`
+also be imported locally using: `imgadm install -m <manifest> -f <file>`
 
 The process looks like this:
 


### PR DESCRIPTION
The change fixes missing missing subcommand for imgadm; 

Example in docs says:
Typically images are downloaded from an image server, however they can also be imported locally using: imgadm -m <manifest> -f <file>

while the real command that is to be used is:
imgadm install -m <manifest> -f <file>

This is verified both by the following example output screen couple of lines below and also by importing local, updated dataset on joyent_20200311T225627Z.

