### PR TITLE
Update how-to-create-a-virtual-machine-from-scratch.md

### DIFF
--- a/docs/how-to-create-a-virtual-machine-from-scratch.md
+++ b/docs/how-to-create-a-virtual-machine-from-scratch.md
@@ -109,6 +109,11 @@ ISO image the first time it comes up.
 Please note that the path for the ISO image will be the relative path of
 the ISO to the zone you are in. This is why it starts with the '/'
 
+If you are booting from an img file rather than an iso, this may not work.  
+Instead try:
+
+    vmadm boot b8ab5fc1-8576-45ef-bb51-9826b52a4651 disk=/debian.img,ide
+
 ## Use VNC to Connect to the VM
 
 The `vmadm` tool can print out the information on the VM. You can also


### PR DESCRIPTION
There is no mention of using an img file instead of an iso - for example, synoboot is distributed as an img file, which has three partitions on it and does not boot with the provided instructions.

I've found that using the disk= parameter allows this to boot, but you also have to remove the cdrom line.